### PR TITLE
[#3] 일정 API 구현

### DIFF
--- a/todak-server/src/main/java/com/example/todak_server/TodakServerApplication.java
+++ b/todak-server/src/main/java/com/example/todak_server/TodakServerApplication.java
@@ -2,8 +2,10 @@ package com.example.todak_server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class TodakServerApplication {
 
 	public static void main(String[] args) {

--- a/todak-server/src/main/java/com/example/todak_server/config/SecurityConfig.java
+++ b/todak-server/src/main/java/com/example/todak_server/config/SecurityConfig.java
@@ -17,9 +17,12 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
+//                .authorizeHttpRequests(auth -> auth
+//                        .requestMatchers("/", "/login**", "/oauth2/**").permitAll()
+//                        .anyRequest().authenticated()
+//                )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/login**", "/oauth2/**").permitAll()
-                        .anyRequest().authenticated()
+                        .anyRequest().permitAll()
                 )
                 .oauth2Login(oauth -> oauth
                         .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))

--- a/todak-server/src/main/java/com/example/todak_server/controller/ScheduleController.java
+++ b/todak-server/src/main/java/com/example/todak_server/controller/ScheduleController.java
@@ -1,0 +1,189 @@
+package com.example.todak_server.controller;
+
+import com.example.todak_server.dto.request.GeneralScheduleRequestDto;
+import com.example.todak_server.dto.request.WeeklyScheduleRequestDto;
+import com.example.todak_server.dto.response.GeneralScheduleResponseDto;
+import com.example.todak_server.dto.response.WeeklyScheduleResponseDto;
+import com.example.todak_server.entity.*;
+import com.example.todak_server.repository.MemberRepository;
+import com.example.todak_server.service.ScheduleService;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/schedules")
+public class ScheduleController {
+
+    private final MemberRepository memberRepository;
+
+    private final ScheduleService scheduleService;
+
+    public ScheduleController(ScheduleService scheduleService,  MemberRepository memberRepository) {
+        this.scheduleService = scheduleService;
+        this.memberRepository = memberRepository;
+    }
+
+
+    // Weekly 일정 생성 + General 스냅샷 생성
+    @PostMapping("/weekly")
+    public WeeklyScheduleResponseDto createWeeklySchedule(@RequestBody WeeklyScheduleRequestDto dto) {
+        Member member = memberRepository.findById(dto.memberId())
+                .orElseThrow(() -> new IllegalArgumentException("Member not found"));
+
+        WeeklySchedule weekly = new WeeklySchedule();
+        weekly.setMember(member);
+        weekly.setDayOfWeek(DayOfWeek.valueOf(dto.dayOfWeek()));
+        weekly.setStartTime(dto.startTime());
+        weekly.setEndTime(dto.endTime());
+        weekly.setTitle(dto.title());
+        weekly.setColor(dto.color());
+
+        // 기본 범위: 오늘부터 8주 후까지
+        LocalDate start = LocalDate.now();
+        LocalDate end = start.plusWeeks(8);
+
+        WeeklySchedule saved = scheduleService.createWeeklySchedule(weekly, start, end);
+
+        return new WeeklyScheduleResponseDto(
+                saved.getId(),
+                saved.getDayOfWeek().name(),
+                saved.getStartTime(),
+                saved.getEndTime(),
+                saved.getTitle(),
+                saved.getColor()
+        );
+    }
+
+    // 특정 멤버의 Weekly 일정 전체 조회
+    @GetMapping("/weekly/{memberId}")
+    public List<WeeklyScheduleResponseDto> getWeeklySchedules(@PathVariable Long memberId) {
+        Member member = new Member();
+        member.setId(memberId);
+
+        return scheduleService.getWeeklySchedule(member).stream()
+                .map(w -> new WeeklyScheduleResponseDto(
+                        w.getId(),
+                        w.getDayOfWeek().name(),
+                        w.getStartTime(),
+                        w.getEndTime(),
+                        w.getTitle(),
+                        w.getColor()
+                ))
+                .toList();
+    }
+
+    // 특정 멤버의 General 일정 조회 (기간별)
+    @GetMapping("/general/{memberId}")
+    public List<GeneralScheduleResponseDto> getGeneralSchedules(@PathVariable Long memberId,
+                                                                @RequestParam LocalDate startDate,
+                                                                @RequestParam LocalDate endDate) {
+        Member member = new Member();
+        member.setId(memberId);
+
+        return scheduleService.getGeneralSchedule(member, startDate, endDate).stream()
+                .map(g -> new GeneralScheduleResponseDto(
+                        g.getId(),
+                        g.getDate(),
+                        g.getStartTime(),
+                        g.getEndTime(),
+                        g.getTitle(),
+                        g.getColor()
+                ))
+                .toList();
+    }
+
+    // General 일정 단일 생성
+    @PostMapping("/general")
+    public GeneralScheduleResponseDto createGeneral(@RequestBody GeneralScheduleRequestDto dto) {
+        Member member = memberRepository.findById(dto.memberId())
+                .orElseThrow(() -> new IllegalArgumentException("Member not found"));
+
+        GeneralSchedule general = new GeneralSchedule();
+        general.setMember(member);
+        general.setDate(dto.date());
+        general.setStartTime(dto.startTime());
+        general.setEndTime(dto.endTime());
+        general.setTitle(dto.title());
+        general.setColor(dto.color());
+
+        GeneralSchedule saved = scheduleService.createGeneralSchedule(general);
+
+        return new GeneralScheduleResponseDto(
+                saved.getId(),
+                saved.getDate(),
+                saved.getStartTime(),
+                saved.getEndTime(),
+                saved.getTitle(),
+                saved.getColor()
+        );
+    }
+
+    // General 일정 수정
+    @PutMapping("/general/{id}")
+    public GeneralScheduleResponseDto updateGeneral(@PathVariable Long id,
+                                                    @RequestBody GeneralScheduleRequestDto dto) {
+        Member member = new Member();
+        member.setId(dto.memberId());
+
+        GeneralSchedule updated = new GeneralSchedule();
+        updated.setMember(member);
+        updated.setDate(dto.date());
+        updated.setStartTime(dto.startTime());
+        updated.setEndTime(dto.endTime());
+        updated.setTitle(dto.title());
+        updated.setColor(dto.color());
+
+        GeneralSchedule saved = scheduleService.updateGeneralSchedule(id, updated);
+
+        return new GeneralScheduleResponseDto(
+                saved.getId(),
+                saved.getDate(),
+                saved.getStartTime(),
+                saved.getEndTime(),
+                saved.getTitle(),
+                saved.getColor()
+        );
+    }
+
+    // General 일정 삭제 (soft delete)
+    @DeleteMapping("/general/{id}")
+    public void deleteGeneral(@PathVariable Long id) {
+        scheduleService.deleteGeneralSchedule(id);
+    }
+
+    // Weekly 일정 수정
+    @PutMapping("/weekly/{id}")
+    public WeeklyScheduleResponseDto updateWeekly(@PathVariable Long id,
+                                                  @RequestBody WeeklyScheduleRequestDto dto) {
+        Member member = new Member();
+        member.setId(dto.memberId());
+
+        WeeklySchedule updated = new WeeklySchedule();
+        updated.setMember(member);
+        updated.setDayOfWeek(DayOfWeek.valueOf(dto.dayOfWeek()));
+        updated.setStartTime(dto.startTime());
+        updated.setEndTime(dto.endTime());
+        updated.setTitle(dto.title());
+        updated.setColor(dto.color());
+
+        WeeklySchedule saved = scheduleService.updateWeeklySchedule(id, updated);
+
+        return new WeeklyScheduleResponseDto(
+                saved.getId(),
+                saved.getDayOfWeek().name(),
+                saved.getStartTime(),
+                saved.getEndTime(),
+                saved.getTitle(),
+                saved.getColor()
+        );
+    }
+
+    // Weekly 일정 삭제
+    @DeleteMapping("/weekly/{id}")
+    public void deleteWeekly(@PathVariable Long id) {
+        scheduleService.deleteWeeklySchedule(id);
+    }
+
+}

--- a/todak-server/src/main/java/com/example/todak_server/controller/ScheduleController.java
+++ b/todak-server/src/main/java/com/example/todak_server/controller/ScheduleController.java
@@ -39,6 +39,7 @@ public class ScheduleController {
         weekly.setEndTime(dto.endTime());
         weekly.setTitle(dto.title());
         weekly.setColor(dto.color());
+        weekly.setLocation(dto.location());
 
         // 기본 범위: 오늘부터 8주 후까지
         LocalDate start = LocalDate.now();
@@ -52,7 +53,8 @@ public class ScheduleController {
                 saved.getStartTime(),
                 saved.getEndTime(),
                 saved.getTitle(),
-                saved.getColor()
+                saved.getColor(),
+                saved.getLocation()
         );
     }
 
@@ -69,7 +71,8 @@ public class ScheduleController {
                         w.getStartTime(),
                         w.getEndTime(),
                         w.getTitle(),
-                        w.getColor()
+                        w.getColor(),
+                        w.getLocation()
                 ))
                 .toList();
     }
@@ -89,7 +92,8 @@ public class ScheduleController {
                         g.getStartTime(),
                         g.getEndTime(),
                         g.getTitle(),
-                        g.getColor()
+                        g.getColor(),
+                        g.getLocation()
                 ))
                 .toList();
     }
@@ -107,6 +111,7 @@ public class ScheduleController {
         general.setEndTime(dto.endTime());
         general.setTitle(dto.title());
         general.setColor(dto.color());
+        general.setLocation(dto.location());
 
         GeneralSchedule saved = scheduleService.createGeneralSchedule(general);
 
@@ -116,7 +121,8 @@ public class ScheduleController {
                 saved.getStartTime(),
                 saved.getEndTime(),
                 saved.getTitle(),
-                saved.getColor()
+                saved.getColor(),
+                saved.getLocation()
         );
     }
 
@@ -134,6 +140,7 @@ public class ScheduleController {
         updated.setEndTime(dto.endTime());
         updated.setTitle(dto.title());
         updated.setColor(dto.color());
+        updated.setLocation(dto.location());
 
         GeneralSchedule saved = scheduleService.updateGeneralSchedule(id, updated);
 
@@ -143,7 +150,8 @@ public class ScheduleController {
                 saved.getStartTime(),
                 saved.getEndTime(),
                 saved.getTitle(),
-                saved.getColor()
+                saved.getColor(),
+                saved.getLocation()
         );
     }
 
@@ -167,6 +175,7 @@ public class ScheduleController {
         updated.setEndTime(dto.endTime());
         updated.setTitle(dto.title());
         updated.setColor(dto.color());
+        updated.setLocation(dto.location());
 
         WeeklySchedule saved = scheduleService.updateWeeklySchedule(id, updated);
 
@@ -176,7 +185,8 @@ public class ScheduleController {
                 saved.getStartTime(),
                 saved.getEndTime(),
                 saved.getTitle(),
-                saved.getColor()
+                saved.getColor(),
+                saved.getLocation()
         );
     }
 

--- a/todak-server/src/main/java/com/example/todak_server/dto/request/GeneralScheduleRequestDto.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/request/GeneralScheduleRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.todak_server.dto.request;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record GeneralScheduleRequestDto(
+        Long memberId,
+        LocalDate date,
+        LocalTime startTime,
+        LocalTime endTime,
+        String title,
+        String color
+) {}

--- a/todak-server/src/main/java/com/example/todak_server/dto/request/GeneralScheduleRequestDto.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/request/GeneralScheduleRequestDto.java
@@ -9,5 +9,6 @@ public record GeneralScheduleRequestDto(
         LocalTime startTime,
         LocalTime endTime,
         String title,
-        String color
+        String color,
+        String location
 ) {}

--- a/todak-server/src/main/java/com/example/todak_server/dto/request/WeeklyScheduleRequestDto.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/request/WeeklyScheduleRequestDto.java
@@ -8,5 +8,6 @@ public record WeeklyScheduleRequestDto(
         LocalTime startTime,
         LocalTime endTime,
         String title,
-        String color
+        String color,
+        String location
 ) {}

--- a/todak-server/src/main/java/com/example/todak_server/dto/request/WeeklyScheduleRequestDto.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/request/WeeklyScheduleRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.todak_server.dto.request;
+
+import java.time.LocalTime;
+
+public record WeeklyScheduleRequestDto(
+        Long memberId,
+        String dayOfWeek,   // "MONDAY", "TUESDAY"
+        LocalTime startTime,
+        LocalTime endTime,
+        String title,
+        String color
+) {}

--- a/todak-server/src/main/java/com/example/todak_server/dto/response/GeneralScheduleResponseDto.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/response/GeneralScheduleResponseDto.java
@@ -9,5 +9,6 @@ public record GeneralScheduleResponseDto(
         LocalTime startTime,
         LocalTime endTime,
         String title,
-        String color
+        String color,
+        String location
 ) {}

--- a/todak-server/src/main/java/com/example/todak_server/dto/response/GeneralScheduleResponseDto.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/response/GeneralScheduleResponseDto.java
@@ -1,0 +1,13 @@
+package com.example.todak_server.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record GeneralScheduleResponseDto(
+        Long id,
+        LocalDate date,
+        LocalTime startTime,
+        LocalTime endTime,
+        String title,
+        String color
+) {}

--- a/todak-server/src/main/java/com/example/todak_server/dto/response/WeeklyScheduleResponseDto.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/response/WeeklyScheduleResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.todak_server.dto.response;
+
+import java.time.LocalTime;
+
+public record WeeklyScheduleResponseDto(
+        Long id,
+        String dayOfWeek,
+        LocalTime startTime,
+        LocalTime endTime,
+        String title,
+        String color
+) {}

--- a/todak-server/src/main/java/com/example/todak_server/dto/response/WeeklyScheduleResponseDto.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/response/WeeklyScheduleResponseDto.java
@@ -8,5 +8,6 @@ public record WeeklyScheduleResponseDto(
         LocalTime startTime,
         LocalTime endTime,
         String title,
-        String color
+        String color,
+        String location
 ) {}

--- a/todak-server/src/main/java/com/example/todak_server/entity/DayOfWeek.java
+++ b/todak-server/src/main/java/com/example/todak_server/entity/DayOfWeek.java
@@ -1,0 +1,11 @@
+package com.example.todak_server.entity;
+
+public enum DayOfWeek {
+    MONDAY,
+    TUESDAY,
+    WEDNESDAY,
+    THURSDAY,
+    FRIDAY,
+    SATURDAY,
+    SUNDAY,
+}

--- a/todak-server/src/main/java/com/example/todak_server/entity/GeneralSchedule.java
+++ b/todak-server/src/main/java/com/example/todak_server/entity/GeneralSchedule.java
@@ -21,7 +21,17 @@ public class GeneralSchedule {
     private LocalTime endTime;
 
     private String title;
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
     private String color;
+    private String location;
 
     public Long getId() {
         return id;

--- a/todak-server/src/main/java/com/example/todak_server/entity/GeneralSchedule.java
+++ b/todak-server/src/main/java/com/example/todak_server/entity/GeneralSchedule.java
@@ -1,0 +1,112 @@
+package com.example.todak_server.entity;
+
+
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+public class GeneralSchedule {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private LocalDate date;
+    private LocalTime startTime;
+    private LocalTime endTime;
+
+    private String title;
+    private String color;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public void setMember(Member member) {
+        this.member = member;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+
+    public LocalTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public LocalTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalTime endTime) {
+        this.endTime = endTime;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+
+    public boolean isDeleted() {
+        return isDeleted;
+    }
+
+    public void setDeleted(boolean deleted) {
+        isDeleted = deleted;
+    }
+
+    public SourceType getSourceType() {
+        return sourceType;
+    }
+
+    public void setSourceType(SourceType sourceType) {
+        this.sourceType = sourceType;
+    }
+
+    public Long getSourceId() {
+        return sourceId;
+    }
+
+    public void setSourceId(Long sourceId) {
+        this.sourceId = sourceId;
+    }
+
+    private boolean isDeleted = false;
+
+    @Enumerated(EnumType.STRING)
+    private SourceType sourceType; // 일주일 시간표 or 일반 일정
+
+    private Long sourceId; // 원본 id
+}

--- a/todak-server/src/main/java/com/example/todak_server/entity/SourceType.java
+++ b/todak-server/src/main/java/com/example/todak_server/entity/SourceType.java
@@ -1,0 +1,5 @@
+package com.example.todak_server.entity;
+
+public enum SourceType {
+    WEEKLY, GENERAL
+}

--- a/todak-server/src/main/java/com/example/todak_server/entity/WeeklySchedule.java
+++ b/todak-server/src/main/java/com/example/todak_server/entity/WeeklySchedule.java
@@ -1,0 +1,81 @@
+package com.example.todak_server.entity;
+
+import jakarta.persistence.*;
+
+import java.time.LocalTime;
+
+@Entity
+public class WeeklySchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private Member member;
+
+    @Enumerated
+    private DayOfWeek dayOfWeek; //월~일
+
+    private LocalTime startTime;
+    private LocalTime endTime;
+
+    private String title;
+    private String color;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public void setMember(Member member) {
+        this.member = member;
+    }
+
+    public DayOfWeek getDayOfWeek() {
+        return dayOfWeek;
+    }
+
+    public void setDayOfWeek(DayOfWeek dayOfWeek) {
+        this.dayOfWeek = dayOfWeek;
+    }
+
+    public LocalTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public LocalTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalTime endTime) {
+        this.endTime = endTime;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+}

--- a/todak-server/src/main/java/com/example/todak_server/entity/WeeklySchedule.java
+++ b/todak-server/src/main/java/com/example/todak_server/entity/WeeklySchedule.java
@@ -22,6 +22,15 @@ public class WeeklySchedule {
 
     private String title;
     private String color;
+    private String location;
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
 
     public Long getId() {
         return id;

--- a/todak-server/src/main/java/com/example/todak_server/repository/GeneralScheduleRepository.java
+++ b/todak-server/src/main/java/com/example/todak_server/repository/GeneralScheduleRepository.java
@@ -1,0 +1,20 @@
+package com.example.todak_server.repository;
+
+import com.example.todak_server.entity.GeneralSchedule;
+import com.example.todak_server.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface GeneralScheduleRepository extends JpaRepository<GeneralSchedule,Long> {
+
+    // 특정 사용자의 일정 전체 조회
+    List<GeneralSchedule> findByMember(Member member);
+
+    // 특정 사용자의 일정 중 특정 기간 조회 (ex. 먼슬리 캘린더 ..)
+    List<GeneralSchedule> findByMemberAndDateBetween(Member member, LocalDate start, LocalDate end);
+
+    // sourceId로 연결된 general 일정 찾기 (일주일 시간표로 생성된 일정들 찾기.)
+    List<GeneralSchedule> findBySourceId(Long sourceId);
+}

--- a/todak-server/src/main/java/com/example/todak_server/repository/MemberRepository.java
+++ b/todak-server/src/main/java/com/example/todak_server/repository/MemberRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member,String> {
     Optional<Member> findByProviderAndProviderId(String provider, String providerId);
+    Optional<Member> findById(Long id);
 }

--- a/todak-server/src/main/java/com/example/todak_server/repository/WeeklyScheduleRepository.java
+++ b/todak-server/src/main/java/com/example/todak_server/repository/WeeklyScheduleRepository.java
@@ -1,0 +1,16 @@
+package com.example.todak_server.repository;
+
+import com.example.todak_server.entity.Member;
+import com.example.todak_server.entity.WeeklySchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface WeeklyScheduleRepository extends JpaRepository<WeeklySchedule,Long> {
+
+    // 특정 사용자의 모든 일주일 시간표 조회
+    List<WeeklySchedule> findByMember(Member member);
+
+    // 특정 사용자의 특정 요일에 해당하는 시간표 조회
+    List<WeeklySchedule> findByMemberAndDayOfWeek(Member member, com.example.todak_server.entity.DayOfWeek dayOfWeek);
+}

--- a/todak-server/src/main/java/com/example/todak_server/service/ScheduleService.java
+++ b/todak-server/src/main/java/com/example/todak_server/service/ScheduleService.java
@@ -6,11 +6,13 @@ import com.example.todak_server.entity.SourceType;
 import com.example.todak_server.entity.WeeklySchedule;
 import com.example.todak_server.repository.GeneralScheduleRepository;
 import com.example.todak_server.repository.WeeklyScheduleRepository;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 @Service
@@ -123,6 +125,48 @@ public class ScheduleService {
         for (GeneralSchedule g : generals) {
             if (g.getDate().isAfter(LocalDate.now())) {
                 generalRepo.delete(g);
+            }
+        }
+    }
+
+    /**
+     * 매주 월요일 0시에 자동으로 General 일정 연장
+     */
+    @Scheduled(cron = "0 0 0 * * MON")
+    @Transactional
+    public void extendWeeklySchedules() {
+        List<WeeklySchedule> allWeeklies = weeklyRepo.findAll();
+        LocalDate today = LocalDate.now();
+        LocalDate limit = today.plusWeeks(8);
+
+        for (WeeklySchedule weekly : allWeeklies) {
+            // 이 Weekly 일정에 연결된 General 중 가장 마지막 날짜 확인
+            List<GeneralSchedule> generals = generalRepo.findBySourceId(weekly.getId());
+            LocalDate latest = generals.stream()
+                    .map(GeneralSchedule::getDate)
+                    .max(LocalDate::compareTo)
+                    .orElse(today.minusDays(1)); // 없으면 과거 날짜로 설정
+
+            // 마지막 스냅샷이 8주보다 짧으면 연장 필요
+            if (ChronoUnit.WEEKS.between(today, latest) < 8) {
+                LocalDate nextDate = latest.plusWeeks(1);
+
+                // 다음 주차부터 limit(8주 후)까지 반복 생성
+                while (!nextDate.isAfter(limit)) {
+                    if (nextDate.getDayOfWeek().name().equals(weekly.getDayOfWeek().name())) {
+                        GeneralSchedule g = new GeneralSchedule();
+                        g.setMember(weekly.getMember());
+                        g.setDate(nextDate);
+                        g.setStartTime(weekly.getStartTime());
+                        g.setEndTime(weekly.getEndTime());
+                        g.setTitle(weekly.getTitle());
+                        g.setColor(weekly.getColor());
+                        g.setSourceType(SourceType.WEEKLY);
+                        g.setSourceId(weekly.getId());
+                        generalRepo.save(g);
+                    }
+                    nextDate = nextDate.plusDays(1);
+                }
             }
         }
     }

--- a/todak-server/src/main/java/com/example/todak_server/service/ScheduleService.java
+++ b/todak-server/src/main/java/com/example/todak_server/service/ScheduleService.java
@@ -44,6 +44,7 @@ public class ScheduleService {
                 general.setColor(weekly.getColor());
                 general.setSourceType(SourceType.WEEKLY);
                 general.setSourceId(saved.getId());
+                general.setLocation(weekly.getLocation());
 
                 generalRepo.save(general);
             }
@@ -76,6 +77,7 @@ public class ScheduleService {
         general.setStartTime(updated.getStartTime());
         general.setEndTime(updated.getEndTime());
         general.setColor(updated.getColor());
+        general.setLocation(updated.getLocation());
         return general;
     }
 
@@ -98,6 +100,7 @@ public class ScheduleService {
         weekly.setEndTime(updated.getEndTime());
         weekly.setTitle(updated.getTitle());
         weekly.setColor(updated.getColor());
+        weekly.setLocation(updated.getLocation());
 
         // General 일정 반영: 과거는 그대로 두고 미래만 수정하는 로직 필요
         List<GeneralSchedule> generals = generalRepo.findBySourceId(id);
@@ -107,6 +110,7 @@ public class ScheduleService {
                 g.setEndTime(updated.getEndTime());
                 g.setTitle(updated.getTitle());
                 g.setColor(updated.getColor());
+                g.setLocation(updated.getLocation());
             }
         }
 
@@ -163,6 +167,7 @@ public class ScheduleService {
                         g.setColor(weekly.getColor());
                         g.setSourceType(SourceType.WEEKLY);
                         g.setSourceId(weekly.getId());
+                        g.setLocation(weekly.getLocation());
                         generalRepo.save(g);
                     }
                     nextDate = nextDate.plusDays(1);

--- a/todak-server/src/main/java/com/example/todak_server/service/ScheduleService.java
+++ b/todak-server/src/main/java/com/example/todak_server/service/ScheduleService.java
@@ -1,0 +1,130 @@
+package com.example.todak_server.service;
+
+import com.example.todak_server.entity.GeneralSchedule;
+import com.example.todak_server.entity.Member;
+import com.example.todak_server.entity.SourceType;
+import com.example.todak_server.entity.WeeklySchedule;
+import com.example.todak_server.repository.GeneralScheduleRepository;
+import com.example.todak_server.repository.WeeklyScheduleRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Service
+@Transactional
+public class ScheduleService {
+
+    private final WeeklyScheduleRepository weeklyRepo;
+    private final GeneralScheduleRepository generalRepo;
+
+    public ScheduleService(WeeklyScheduleRepository weeklyRepo, GeneralScheduleRepository generalRepo) {
+        this.weeklyRepo = weeklyRepo;
+        this.generalRepo = generalRepo;
+    }
+
+    // 1. 일주일 시간표 생성 + General 스냅샷 생성
+    public WeeklySchedule createWeeklySchedule(WeeklySchedule weekly, LocalDate startDate, LocalDate endDate) {
+        WeeklySchedule saved = weeklyRepo.save(weekly);
+
+        // Weekly 기반으로 General 일정 여러 개 생성 (스냅샷)
+        LocalDate date = startDate;
+        while (!date.isAfter(endDate)) {
+            if (date.getDayOfWeek().name().equals(weekly.getDayOfWeek().name())) {
+                GeneralSchedule general = new GeneralSchedule();
+                general.setMember(weekly.getMember());
+                general.setDate(date);
+                general.setStartTime(weekly.getStartTime());
+                general.setEndTime(weekly.getEndTime());
+                general.setTitle(weekly.getTitle());
+                general.setColor(weekly.getColor());
+                general.setSourceType(SourceType.WEEKLY);
+                general.setSourceId(saved.getId());
+
+                generalRepo.save(general);
+            }
+            date = date.plusDays(1);
+        }
+        return saved;
+    }
+
+    // 2. 특정 멤버의 일주일 시간표 조회
+    public List<WeeklySchedule> getWeeklySchedule(Member member) {
+        return weeklyRepo.findByMember(member);
+    }
+
+    // 3. 특정 사용자의 일정 중 특정 기간 조회 (ex. 먼슬리 캘린더 ..)
+    public List<GeneralSchedule> getGeneralSchedule(Member member, LocalDate startDate, LocalDate endDate) {
+        return generalRepo.findByMemberAndDateBetween(member,startDate,endDate);
+    }
+
+    // 4. General 일정 단일 생성
+    public GeneralSchedule createGeneralSchedule(GeneralSchedule general) {
+        general.setSourceType(SourceType.GENERAL);
+        return generalRepo.save(general);
+    }
+
+    // 5. General 일정 수정
+    public GeneralSchedule updateGeneralSchedule(Long id, GeneralSchedule updated) {
+        GeneralSchedule general = generalRepo.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("general 일정을 찾을 수 없습니다."));
+        general.setTitle(updated.getTitle());
+        general.setStartTime(updated.getStartTime());
+        general.setEndTime(updated.getEndTime());
+        general.setColor(updated.getColor());
+        return general;
+    }
+
+    // 6. General 일정 삭제 (soft delete)
+    public void deleteGeneralSchedule(Long id) {
+        GeneralSchedule general = generalRepo.findById(id)
+                .orElseThrow( () -> new IllegalArgumentException("general 일정을 찾을 수 없습니다."));
+        general.setDeleted(true);
+    }
+
+
+
+    // Weekly 일정 수정
+    public WeeklySchedule updateWeeklySchedule(Long id, WeeklySchedule updated) {
+        WeeklySchedule weekly = weeklyRepo.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Weekly 일정을 찾을 수 없습니다."));
+
+        weekly.setDayOfWeek(updated.getDayOfWeek());
+        weekly.setStartTime(updated.getStartTime());
+        weekly.setEndTime(updated.getEndTime());
+        weekly.setTitle(updated.getTitle());
+        weekly.setColor(updated.getColor());
+
+        // General 일정 반영: 과거는 그대로 두고 미래만 수정하는 로직 필요
+        List<GeneralSchedule> generals = generalRepo.findBySourceId(id);
+        for (GeneralSchedule g : generals) {
+            if (g.getDate().isAfter(LocalDate.now())) { // 오늘 이후 일정만 수정
+                g.setStartTime(updated.getStartTime());
+                g.setEndTime(updated.getEndTime());
+                g.setTitle(updated.getTitle());
+                g.setColor(updated.getColor());
+            }
+        }
+
+        return weekly;
+    }
+
+    // Weekly 일정 삭제
+    public void deleteWeeklySchedule(Long id) {
+        WeeklySchedule weekly = weeklyRepo.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Weekly 일정을 찾을 수 없습니다."));
+
+        weeklyRepo.delete(weekly);
+
+        // General 일정 처리: 과거는 유지, 미래는 삭제
+        List<GeneralSchedule> generals = generalRepo.findBySourceId(id);
+        for (GeneralSchedule g : generals) {
+            if (g.getDate().isAfter(LocalDate.now())) {
+                generalRepo.delete(g);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
- source_type으로 WEEKLY/GENERAL 구분
- general 삭제는 soft delete. (일주일 시간표는 그냥 delete)
- weekly 수정 시 과거 general 수정 X, 미래 general만 수정 O
- weekly 삭제 시 과거 general 삭제 X, 미래 general만 삭제 O
- weekly 생성 시 우선 general은 8주 분량만큼만 생성되고, 그 기간이 지나면 자동 갱신되도록 구현.