### PR TITLE
Feat: 관리자의 근무 스케줄 등록/수정/조회/삭제 기능 구현

### DIFF
--- a/todak-server/build.gradle
+++ b/todak-server/build.gradle
@@ -47,6 +47,8 @@ dependencies {
 	implementation 'com.google.firebase:firebase-admin:9.2.0'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	implementation 'com.google.firebase:firebase-admin:9.3.0'
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter', version: '1.2.5.RELEASE'
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-storage', version: '1.2.5.RELEASE'
 }
 
 tasks.named('test') {

--- a/todak-server/src/main/java/com/example/todak_server/config/GcsConfig.java
+++ b/todak-server/src/main/java/com/example/todak_server/config/GcsConfig.java
@@ -1,0 +1,33 @@
+package com.example.todak_server.config;
+
+import com.google.cloud.storage.Storage;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.StorageOptions;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Configuration
+public class GcsConfig {
+
+    @Value("${gcp.storage.credentials.location}")
+    private String credentialsPath;
+
+    @Value("${gcp.storage.project-id}")
+    private String projectId;
+
+    @Bean
+    public Storage storage() throws IOException {
+        InputStream keyStream = new ClassPathResource(credentialsPath.substring("classpath:".length())).getInputStream();
+
+        return StorageOptions.newBuilder()
+                .setCredentials(GoogleCredentials.fromStream(keyStream))
+                .setProjectId(projectId)
+                .build()
+                .getService();
+    }
+}

--- a/todak-server/src/main/java/com/example/todak_server/controller/WorkScheduleController.java
+++ b/todak-server/src/main/java/com/example/todak_server/controller/WorkScheduleController.java
@@ -1,0 +1,82 @@
+package com.example.todak_server.controller;
+
+import com.example.todak_server.dto.request.WorkScheduleCreateRequest;
+import com.example.todak_server.dto.request.WorkScheduleUpdateRequest;
+import com.example.todak_server.dto.response.WorkScheduleDetailResponse;
+import com.example.todak_server.dto.response.WorkScheduleSimpleResponse;
+import com.example.todak_server.service.WorkScheduleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Tag(name = "근무 스케줄 API", description = "근무 스케줄 등록/수정/조회/삭제 기능 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/schedules")
+public class WorkScheduleController {
+
+    private final WorkScheduleService workScheduleService;
+
+    // 스케줄 등록
+    @Operation(summary = "근무 스케줄 등록", description = "새로운 근무 스케줄을 등록함. 이미지 파일 업로드를 지원함.")
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<WorkScheduleDetailResponse> create(
+            @Parameter(description = "스케줄 정보(JSON)")
+            @RequestPart("data") WorkScheduleCreateRequest request,
+
+            @Parameter(description = "작업환경 이미지 (선택)")
+            @RequestPart(value = "imageFile", required = false) MultipartFile imageFile
+    ) {
+        return ResponseEntity.ok(
+                workScheduleService.create(request, imageFile)
+        );
+    }
+
+    // 스케줄 수정
+    @Operation(summary = "근무 스케줄 수정", description = "기존 근무 스케줄 정보를 수정함. 이미지도 교체 가능함.")
+    @PutMapping(value = "/{scheduleId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<WorkScheduleDetailResponse> update(
+            @Parameter(description = "스케줄 ID")
+            @PathVariable Long scheduleId,
+
+            @Parameter(description = "수정할 스케줄 데이터(JSON)")
+            @RequestPart("data") WorkScheduleUpdateRequest request,
+
+            @Parameter(description = "새로운 이미지 파일 (선택)")
+            @RequestPart(value = "imageFile", required = false) MultipartFile imageFile
+    ) {
+        return ResponseEntity.ok(
+                workScheduleService.update(scheduleId, request, imageFile)
+        );
+    }
+
+    // 월별 스케줄 조회
+    @Operation(summary = "월별 스케줄 조회", description = "특정 구성원의 특정 연/월에 해당하는 근무 스케줄을 조회함.")
+    @GetMapping
+    public ResponseEntity<List<WorkScheduleSimpleResponse>> getMonthly(
+            @Parameter(description = "멤버 ID") @RequestParam Long memberId,
+            @Parameter(description = "연도") @RequestParam int year,
+            @Parameter(description = "월") @RequestParam int month
+    ) {
+        return ResponseEntity.ok(
+                workScheduleService.getMonthly(memberId, year, month)
+        );
+    }
+
+    // 스케줄 삭제
+    @Operation(summary = "근무 스케줄 삭제", description = "스케줄 ID에 해당하는 근무 스케줄을 삭제함.")
+    @DeleteMapping("/{scheduleId}")
+    public ResponseEntity<Void> delete(@PathVariable Long scheduleId) {
+
+        workScheduleService.delete(scheduleId);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/todak-server/src/main/java/com/example/todak_server/dto/request/WorkScheduleCreateRequest.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/request/WorkScheduleCreateRequest.java
@@ -1,0 +1,12 @@
+package com.example.todak_server.dto.request;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record WorkScheduleCreateRequest(
+        Long memberId,
+        LocalDate date,
+        LocalTime startTime,
+        LocalTime endTime,
+        String description
+) {}

--- a/todak-server/src/main/java/com/example/todak_server/dto/request/WorkScheduleUpdateRequest.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/request/WorkScheduleUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.example.todak_server.dto.request;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record WorkScheduleUpdateRequest(
+        LocalDate date,
+        LocalTime startTime,
+        LocalTime endTime,
+        String description
+) {}

--- a/todak-server/src/main/java/com/example/todak_server/dto/response/WorkScheduleDetailResponse.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/response/WorkScheduleDetailResponse.java
@@ -1,0 +1,18 @@
+package com.example.todak_server.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public record WorkScheduleDetailResponse(
+        Long scheduleId,
+        Long memberId,
+        String memberName,
+        LocalDate date,
+        LocalTime startTime,
+        LocalTime endTime,
+        String description,
+        String imgUrl,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {}

--- a/todak-server/src/main/java/com/example/todak_server/dto/response/WorkScheduleSimpleResponse.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/response/WorkScheduleSimpleResponse.java
@@ -1,0 +1,12 @@
+package com.example.todak_server.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record WorkScheduleSimpleResponse(
+        Long scheduleId,
+        LocalDate date,
+        LocalTime startTime,
+        LocalTime endTime,
+        String imgUrl
+) {}

--- a/todak-server/src/main/java/com/example/todak_server/entity/WorkSchedule.java
+++ b/todak-server/src/main/java/com/example/todak_server/entity/WorkSchedule.java
@@ -1,0 +1,53 @@
+package com.example.todak_server.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WorkSchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private LocalDate date;
+
+    private LocalTime startTime;
+
+    private LocalTime endTime;
+
+    @Column(length = 500)
+    private String description;
+
+    private String imgUrl;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}
+

--- a/todak-server/src/main/java/com/example/todak_server/repository/WorkScheduleRepository.java
+++ b/todak-server/src/main/java/com/example/todak_server/repository/WorkScheduleRepository.java
@@ -1,0 +1,14 @@
+package com.example.todak_server.repository;
+
+import com.example.todak_server.entity.Member;
+import com.example.todak_server.entity.WorkSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface WorkScheduleRepository extends JpaRepository<WorkSchedule, Long> {
+    List<WorkSchedule> findByMember(Member member);
+    List<WorkSchedule> findByDateBetween(LocalDate start, LocalDate end);
+    List<WorkSchedule> findByMemberAndDateBetween(Member member, LocalDate start, LocalDate end);
+}

--- a/todak-server/src/main/java/com/example/todak_server/service/WorkScheduleService.java
+++ b/todak-server/src/main/java/com/example/todak_server/service/WorkScheduleService.java
@@ -1,0 +1,128 @@
+package com.example.todak_server.service;
+
+import com.example.todak_server.dto.request.WorkScheduleCreateRequest;
+import com.example.todak_server.dto.request.WorkScheduleUpdateRequest;
+import com.example.todak_server.dto.response.WorkScheduleDetailResponse;
+import com.example.todak_server.dto.response.WorkScheduleSimpleResponse;
+import com.example.todak_server.entity.Member;
+import com.example.todak_server.entity.WorkSchedule;
+import com.example.todak_server.repository.MemberRepository;
+import com.example.todak_server.repository.WorkScheduleRepository;
+import com.example.todak_server.util.GcsUploader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class WorkScheduleService {
+
+    private final WorkScheduleRepository workScheduleRepository;
+    private final MemberRepository memberRepository;
+    private final GcsUploader gcsUploader;
+
+    // 스케줄 등록
+    public WorkScheduleDetailResponse create(
+            WorkScheduleCreateRequest req,
+            MultipartFile imageFile
+    ) {
+        Member member = memberRepository.findById(req.memberId())
+                .orElseThrow(() -> new RuntimeException("직원이 존재하지 않습니다."));
+
+        String imgUrl = null;
+        if (imageFile != null && !imageFile.isEmpty()) {
+            imgUrl = gcsUploader.upload(imageFile, "schedule");
+        }
+
+        WorkSchedule schedule = new WorkSchedule();
+        schedule.setMember(member);
+        schedule.setDate(req.date());
+        schedule.setStartTime(req.startTime());
+        schedule.setEndTime(req.endTime());
+        schedule.setDescription(req.description());
+        schedule.setImgUrl(imgUrl);
+
+        workScheduleRepository.save(schedule);
+
+        return toDetailResponse(schedule);
+    }
+
+    // 스케줄 수정
+    public WorkScheduleDetailResponse update(
+            Long scheduleId,
+            WorkScheduleUpdateRequest req,
+            MultipartFile imageFile
+    ) {
+        WorkSchedule schedule = workScheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new RuntimeException("해당 스케줄을 찾을 수 없습니다."));
+
+        schedule.setDate(req.date());
+        schedule.setStartTime(req.startTime());
+        schedule.setEndTime(req.endTime());
+        schedule.setDescription(req.description());
+
+        if (imageFile != null && !imageFile.isEmpty()) {
+            String imgUrl = gcsUploader.upload(imageFile, "schedule");
+            schedule.setImgUrl(imgUrl);
+        }
+
+        workScheduleRepository.save(schedule);
+        return toDetailResponse(schedule);
+    }
+
+    // 월별 스케줄 조회
+    public List<WorkScheduleSimpleResponse> getMonthly(Long memberId, int year, int month) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("직원 없음"));
+
+        LocalDate start = LocalDate.of(year, month, 1);
+        LocalDate end = start.plusMonths(1).minusDays(1);
+
+        return workScheduleRepository.findByMemberAndDateBetween(member, start, end)
+                .stream()
+                .map(this::toSimpleResponse)
+                .toList();
+    }
+
+    private WorkScheduleDetailResponse toDetailResponse(WorkSchedule s) {
+        return new WorkScheduleDetailResponse(
+                s.getId(),
+                s.getMember().getId(),
+                s.getMember().getNickname(),
+                s.getDate(),
+                s.getStartTime(),
+                s.getEndTime(),
+                s.getDescription(),
+                s.getImgUrl(),
+                s.getCreatedAt(),
+                s.getUpdatedAt()
+        );
+    }
+
+    private WorkScheduleSimpleResponse toSimpleResponse(WorkSchedule s) {
+        return new WorkScheduleSimpleResponse(
+                s.getId(),
+                s.getDate(),
+                s.getStartTime(),
+                s.getEndTime(),
+                s.getImgUrl()
+        );
+    }
+
+    // 스케줄 삭제
+    public void delete(Long scheduleId) {
+
+        WorkSchedule schedule = workScheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new RuntimeException("스케줄을 찾을 수 없습니다."));
+
+        // 이미지 삭제
+         if (schedule.getImgUrl() != null) {
+             gcsUploader.delete(schedule.getImgUrl());
+         }
+
+        workScheduleRepository.delete(schedule);
+    }
+}

--- a/todak-server/src/main/java/com/example/todak_server/util/GcsUploader.java
+++ b/todak-server/src/main/java/com/example/todak_server/util/GcsUploader.java
@@ -1,0 +1,51 @@
+package com.example.todak_server.util;
+
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class GcsUploader {
+
+    @Value("${gcp.storage.bucket}")
+    private String bucket;
+
+    private final Storage storage;
+
+
+    // 이미지 업로드
+    public String upload(MultipartFile file, String dirName) {
+        try {
+            String fileName = dirName + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+
+            BlobInfo blobInfo = BlobInfo.newBuilder(bucket, fileName)
+                    .setContentType(file.getContentType())
+                    .build();
+
+            storage.create(blobInfo, file.getBytes());
+
+            return String.format("https://storage.googleapis.com/%s/%s", bucket, fileName);
+
+        } catch (IOException e) {
+            throw new RuntimeException("GCS 파일 업로드 실패: " + e.getMessage());
+        }
+    }
+
+    // 이미지 삭제
+    public void delete(String fileUrl) {
+        try {
+            String fileName = fileUrl.substring(fileUrl.indexOf("/", 50) + 1);
+            storage.delete(bucket, fileName);
+        } catch (Exception e) {
+            throw new RuntimeException("GCS 파일 삭제 실패");
+        }
+    }
+}

--- a/todak-server/src/main/resources/application-dev.yml
+++ b/todak-server/src/main/resources/application-dev.yml
@@ -10,5 +10,11 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
+gcp:
+  storage:
+    credentials:
+      location: classpath:gcs/todak-storage-for-images.json
+    project-id: todak-for-daily
+    bucket: todak-images
 server:
   port: 8080

--- a/todak-server/src/main/resources/application.yml
+++ b/todak-server/src/main/resources/application.yml
@@ -9,5 +9,11 @@ firebase:
 #    path: classpath:firebase/serviceAccountKey.json
   storage:
     bucket: todak-for-daily.firebasestorage.app
+gcp:
+  storage:
+    credentials:
+      location: classpath:gcs/todak-storage-for-images.json
+    project-id: todak-for-daily
+    bucket: todak-images
 env:
   FIREBASE_CONFIG: ${{ secrets.FIREBASE_CONFIG }}


### PR DESCRIPTION
Resolved #32 

<br>

---


### 1. 근무 스케줄 등록
```
POST /api/admin/schedules
```

- 새로운 근무 스케줄을 등록함
- (선택) 이미지 파일 업로드 가능함
   - 해당 스케줄에 일하게 될 근무환경 이미지 등 
   - png, jpg 등 지원함 
 


<details>
<summary>Postman 결과</summary>
<div markdown="1">



<img src="https://github.com/user-attachments/assets/181687d8-ed16-4b23-a27f-f8721581257f" width="600"/>

</div>
</details>

<br>


### 2. 근무 스케줄 수정

```
PUT /api/admin/schedules/{scheduleId}
```

- 기존의 근무 스케줄 정보를 수정함 
- (선택) 이미지 교체도 가능함

<details>
<summary>Postman 결과</summary>
<div markdown="1">



<img src="https://github.com/user-attachments/assets/af983bd0-7ae2-40de-abc4-7a87b7b6baf2" width="600"/>

</div>
</details>

<br>


### 3. 직원별 월별 스케줄 조회 

```
GET /api/admin/schedules?memberId=1year=2025&month=11
```

- 특정 구성원의 특정 연/월에 해당하는 근무 스케줄을 조회 

<details>
<summary>Postman 결과</summary>
<div markdown="1">




<img src="https://github.com/user-attachments/assets/0adac95f-a3dc-4858-8ff9-14ab7ee4f33e" width="600"/>

</div>
</details>



<br>


### 4. 스케줄 삭제 

```
DELETE /api/admin/schedules/{scheduleId}
```

- 스케줄 ID에 해당하는 근무 스케줄을 삭제함 


<br>


