### PR TITLE
Feat: 근무 환경 및 주의사항 등록/조회/읽음 처리 & 미확인 알림 발송

### DIFF
--- a/todak-server/src/main/java/com/example/todak_server/controller/CautionController.java
+++ b/todak-server/src/main/java/com/example/todak_server/controller/CautionController.java
@@ -1,0 +1,51 @@
+package com.example.todak_server.controller;
+
+import com.example.todak_server.dto.request.*;
+import com.example.todak_server.dto.response.CautionResponse;
+import com.example.todak_server.service.CautionService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Tag(name = "주의사항 및 작업 환경 API", description = "근무 환경 이미지/영상 업로드, 주의사항 등록/조회/읽음 기능 API")
+@RestController
+@RequestMapping("/api/cautions")
+@RequiredArgsConstructor
+public class CautionController {
+
+    private final CautionService cautionService;
+
+    @Operation(summary = "주의사항 등록", description = "관리자가 필독 주의사항을 등록하고 이미지/영상을 업로드함.")
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public CautionResponse createCaution(
+            @RequestPart("data") CautionCreateRequest request,
+            @RequestPart(value = "imageFile", required = false) MultipartFile imageFile
+    ) {
+        return cautionService.create(request, imageFile);
+    }
+
+    @Operation(summary = "주의사항 조회", description = "해당 직원에게 배정된 전체 주의사항을 조회함.")
+    @GetMapping
+    public List<CautionResponse> getList(
+            @RequestParam Long memberId
+    ) {
+        return cautionService.getList(memberId);
+    }
+
+    @Operation(summary = "읽음 처리", description = "직원이 특정 주의사항을 확인했음을 표시함.")
+    @PostMapping("/read")
+    public String markAsRead(
+            @RequestBody CautionReadRequest req
+    ) {
+        cautionService.markAsRead(req.memberId(), req.cautionId());
+        return "OK";
+    }
+}

--- a/todak-server/src/main/java/com/example/todak_server/dto/request/CautionCreateRequest.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/request/CautionCreateRequest.java
@@ -1,0 +1,9 @@
+package com.example.todak_server.dto.request;
+
+public record CautionCreateRequest(
+        Long memberId,
+        Long managerId,
+        String title,
+        String description,
+        Integer notifyAfterHours
+) {}

--- a/todak-server/src/main/java/com/example/todak_server/dto/request/CautionReadRequest.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/request/CautionReadRequest.java
@@ -1,0 +1,6 @@
+package com.example.todak_server.dto.request;
+
+public record CautionReadRequest(
+        Long memberId,
+        Long cautionId
+) {}

--- a/todak-server/src/main/java/com/example/todak_server/dto/response/CautionResponse.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/response/CautionResponse.java
@@ -1,0 +1,15 @@
+package com.example.todak_server.dto.response;
+
+import lombok.Builder;
+import java.time.LocalDateTime;
+
+@Builder
+public record CautionResponse(
+        Long id,
+        String title,
+        String description,
+        String fileUrl,
+        boolean isRead,
+        Integer notifyAfterHours,
+        LocalDateTime createdAt
+) {}

--- a/todak-server/src/main/java/com/example/todak_server/entity/Caution.java
+++ b/todak-server/src/main/java/com/example/todak_server/entity/Caution.java
@@ -1,0 +1,36 @@
+package com.example.todak_server.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Caution {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @Column(length = 2000)
+    private String description;
+
+    private String fileUrl;
+
+    private Integer notifyAfterHours;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "manager_id")
+    private Admin manager; // 작성한 관리자
+
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/todak-server/src/main/java/com/example/todak_server/entity/CautionRead.java
+++ b/todak-server/src/main/java/com/example/todak_server/entity/CautionRead.java
@@ -1,0 +1,35 @@
+package com.example.todak_server.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CautionRead {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "caution_id")
+    private Caution caution;
+
+    private boolean isRead;
+
+    private boolean notified; // 알림 발송 여부
+
+    private LocalDateTime readAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.isRead = false;
+        this.notified = false;
+    }
+}

--- a/todak-server/src/main/java/com/example/todak_server/repository/CautionReadRepository.java
+++ b/todak-server/src/main/java/com/example/todak_server/repository/CautionReadRepository.java
@@ -1,0 +1,14 @@
+package com.example.todak_server.repository;
+
+import com.example.todak_server.entity.CautionRead;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CautionReadRepository extends JpaRepository<CautionRead, Long> {
+
+    Optional<CautionRead> findByMemberIdAndCautionId(Long memberId, Long cautionId);
+    List<CautionRead> findByMemberId(Long memberId);
+    List<CautionRead> findByIsReadFalseAndNotifiedFalse();
+}

--- a/todak-server/src/main/java/com/example/todak_server/repository/CautionRepository.java
+++ b/todak-server/src/main/java/com/example/todak_server/repository/CautionRepository.java
@@ -1,0 +1,7 @@
+package com.example.todak_server.repository;
+
+import com.example.todak_server.entity.Caution;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CautionRepository extends JpaRepository<Caution, Long> {
+}

--- a/todak-server/src/main/java/com/example/todak_server/scheduler/CautionScheduler.java
+++ b/todak-server/src/main/java/com/example/todak_server/scheduler/CautionScheduler.java
@@ -1,0 +1,49 @@
+package com.example.todak_server.scheduler;
+
+import com.example.todak_server.entity.CautionRead;
+import com.example.todak_server.repository.CautionReadRepository;
+import com.example.todak_server.service.FcmService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CautionScheduler {
+
+    private final CautionReadRepository cautionReadRepository;
+    private final FcmService fcmService;
+
+    // 30분마다 검사
+    @Transactional
+    @Scheduled(cron = "0 */30 * * * *")
+    public void sendUnreadNotifications() {
+
+        List<CautionRead> unread = cautionReadRepository.findByIsReadFalseAndNotifiedFalse();
+
+        for (CautionRead cr : unread) {
+
+            LocalDateTime deadline = cr.getCaution()
+                    .getCreatedAt()
+                    .plusHours(cr.getCaution().getNotifyAfterHours());
+
+            if (LocalDateTime.now().isAfter(deadline)) {
+
+                String token = fcmService.getMemberToken(cr.getMemberId());
+
+                fcmService.sendNotification(
+                        token,
+                        "[필독] 안전 주의사항 미확인",
+                        "아직 확인하지 않은 주의사항이 있습니다."
+                );
+
+                cr.setNotified(true);
+                cautionReadRepository.save(cr);
+            }
+        }
+    }
+}

--- a/todak-server/src/main/java/com/example/todak_server/service/CautionService.java
+++ b/todak-server/src/main/java/com/example/todak_server/service/CautionService.java
@@ -1,0 +1,110 @@
+package com.example.todak_server.service;
+
+import com.example.todak_server.dto.request.CautionCreateRequest;
+import com.example.todak_server.dto.response.CautionResponse;
+import com.example.todak_server.entity.*;
+import com.example.todak_server.repository.*;
+import com.example.todak_server.util.GcsUploader;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CautionService {
+
+    private final CautionRepository cautionRepo;
+    private final CautionReadRepository cautionReadRepo;
+    private final AdminRepository adminRepo;
+    private final MemberRepository memberRepo;
+    private final GcsUploader gcsUploader;
+
+    // 1) 관리자: 주의사항 등록
+    @Transactional
+    public CautionResponse create(CautionCreateRequest req, MultipartFile file) {
+
+        Admin manager = adminRepo.findById(req.managerId())
+                .orElseThrow(() -> new RuntimeException("관리자 없음"));
+
+        String fileUrl = null;
+        if (file != null && !file.isEmpty()) {
+            fileUrl = gcsUploader.upload(file, "cautions");
+        }
+
+        Caution caution = cautionRepo.save(
+                Caution.builder()
+                        .title(req.title())
+                        .description(req.description())
+                        .notifyAfterHours(req.notifyAfterHours())
+                        .manager(manager)
+                        .fileUrl(fileUrl)
+                        .build()
+        );
+
+        // 등록된 조직의 모든 직원에게 CautionRead 생성
+        List<Member> members = memberRepo.findAll();
+        for (Member m : members) {
+            cautionReadRepo.save(
+                    CautionRead.builder()
+                            .memberId(m.getId())
+                            .caution(caution)
+                            .build()
+            );
+        }
+
+        return CautionResponse.builder()
+                .id(caution.getId())
+                .title(caution.getTitle())
+                .description(caution.getDescription())
+                .fileUrl(caution.getFileUrl())
+                .notifyAfterHours(caution.getNotifyAfterHours())
+                .isRead(false)
+                .createdAt(caution.getCreatedAt())
+                .build();
+    }
+
+    // 2) 직원: 주의사항 목록 조회
+    @Transactional(readOnly = true)
+    public List<CautionResponse> getList(Long memberId) {
+
+        List<CautionRead> reads = cautionReadRepo.findByMemberId(memberId);
+
+        return reads.stream()
+                .map(cr -> {
+                    Caution c = cr.getCaution();
+                    return CautionResponse.builder()
+                            .id(c.getId())
+                            .title(c.getTitle())
+                            .description(c.getDescription())
+                            .fileUrl(c.getFileUrl())
+                            .isRead(cr.isRead())
+                            .notifyAfterHours(c.getNotifyAfterHours())
+                            .createdAt(c.getCreatedAt())
+                            .build();
+                }).toList();
+    }
+
+    // 3) 직원: 읽음 처리
+    @Transactional
+    public void markAsRead(Long memberId, Long cautionId) {
+
+        CautionRead cr = cautionReadRepo.findByMemberIdAndCautionId(memberId, cautionId)
+                .orElseThrow(() -> new RuntimeException("주의사항 없음"));
+
+        cr = CautionRead.builder()
+                .id(cr.getId())
+                .memberId(memberId)
+                .caution(cr.getCaution())
+                .isRead(true)
+                .notified(cr.isNotified())
+                .readAt(LocalDateTime.now())
+                .build();
+
+        cautionReadRepo.save(cr);
+    }
+}


### PR DESCRIPTION
Resolved #33 
Resolved #37 


<br>

---


### 1. 주의사항 등록 및 이미지 업로드 
```
POST /api/cautions
```

- 새로운 근무 환경 및 주의사항에 대해 등록함 
- (선택) 이미지 파일 업로드 가능함
   - 해당 스케줄에 일하게 될 근무환경 이미지 등 
   - png, jpg 등 지원함 
 


<details>
<summary>Postman 결과</summary>
<div markdown="1">


<img src="https://github.com/user-attachments/assets/9e47936e-f4fb-472f-89d0-0b786914d014" width="600"/>

</div>
</details>

<br>


### 2. 주의사항 조회 

```
GET /api/cautions?memberId=1
```

- 특정 직원에게 할당된 근무 스케줄 정보를 조회함


<details>
<summary>Postman 결과</summary>
<div markdown="1">


<img src="https://github.com/user-attachments/assets/0a10f7b8-9d74-4629-a9e5-31b6570829f3" width="600"/>

</div>
</details>

<br>


### 3. 주의사항 읽음 처리 

```
POST /api/cautions/read
```

- 주의사항을 읽었음을 체크박스에 체크하면, 해당 주의사항에 대해 읽음 처리 

<details>
<summary>Postman 결과</summary>
<div markdown="1">



<img src="https://github.com/user-attachments/assets/7cd12776-3cec-413f-b07d-59dfc30d8e8f" width="600"/>

</div>
</details>



<br>


### 4. 주의사항 미확인 알림 발송 

- 스케줄러가 자동으로 `createdAt + notifyAfterHours` 시간이 지나면, `isRead=false & notified=false`인 직원에게 FCM 푸시 발송 


<br>


