### PR TITLE
Feat: 변경사항 피드/글씨강조/알림 및 읽음 처리

### DIFF
--- a/todak-server/src/main/java/com/example/todak_server/controller/ChangeController.java
+++ b/todak-server/src/main/java/com/example/todak_server/controller/ChangeController.java
@@ -1,0 +1,46 @@
+package com.example.todak_server.controller;
+
+import com.example.todak_server.dto.request.ChangeReadRequest;
+import com.example.todak_server.dto.response.ChangeLogResponse;
+import com.example.todak_server.service.ChangeService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "변경사항 API", description = "변경된 내용 조회 및 읽음 처리 기능 API")
+@RestController
+@RequestMapping("/api/changes")
+@RequiredArgsConstructor
+public class ChangeController {
+
+    private final ChangeService changeService;
+
+    @Operation(summary = "변경사항 조회", description = "해당 직원에게 발생한 변경사항 목록을 조회함.")
+    @GetMapping
+    public List<ChangeLogResponse> getChanges(
+            @RequestParam Long memberId
+    ) {
+        return changeService.getChanges(memberId);
+    }
+
+    @Operation(summary = "안 읽은 변경사항 조회", description = "직원이 아직 읽지 않은 변경사항 목록만 조회함. (빨간 글씨 강조용)")
+    @GetMapping("/unread")
+    public List<ChangeLogResponse> getUnread(@RequestParam Long memberId) {
+        return changeService.getUnreadChanges(memberId);
+    }
+
+    @Operation(summary = "변경사항 읽음 처리", description = "직원이 변경사항을 읽었음을 표시함.")
+    @PostMapping("/read")
+    public String markAsRead(
+            @RequestBody ChangeReadRequest req
+    ) {
+        changeService.markAsRead(req.changeLogIds(), req.memberId());
+        return "OK";
+    }
+}

--- a/todak-server/src/main/java/com/example/todak_server/dto/request/ChangeReadRequest.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/request/ChangeReadRequest.java
@@ -1,0 +1,8 @@
+package com.example.todak_server.dto.request;
+
+import java.util.List;
+
+public record ChangeReadRequest(
+        List<Long> changeLogIds,
+        Long memberId
+) {}

--- a/todak-server/src/main/java/com/example/todak_server/dto/response/ChangeLogResponse.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/response/ChangeLogResponse.java
@@ -1,0 +1,16 @@
+package com.example.todak_server.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ChangeLogResponse(
+        Long changeLogId,
+        String category,
+        String fieldName,
+        String oldValue,
+        String newValue,
+        LocalDateTime changedAt,
+        boolean isRead   // 읽음 여부
+) {}

--- a/todak-server/src/main/java/com/example/todak_server/entity/ChangeLog.java
+++ b/todak-server/src/main/java/com/example/todak_server/entity/ChangeLog.java
@@ -1,0 +1,25 @@
+package com.example.todak_server.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChangeLog {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;          // 직원 ID
+    private String category;        // 변경된 요소
+    private String fieldName;       // 변경된 필드명
+    private String oldValue;
+    private String newValue;
+
+    private LocalDateTime changedAt;
+}

--- a/todak-server/src/main/java/com/example/todak_server/entity/ChangeRead.java
+++ b/todak-server/src/main/java/com/example/todak_server/entity/ChangeRead.java
@@ -1,0 +1,24 @@
+package com.example.todak_server.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChangeRead {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;
+    private Long changeLogId;
+
+    private boolean isRead;
+    private boolean notified;
+    private LocalDateTime createdAt;
+}

--- a/todak-server/src/main/java/com/example/todak_server/repository/ChangeLogRepository.java
+++ b/todak-server/src/main/java/com/example/todak_server/repository/ChangeLogRepository.java
@@ -1,0 +1,11 @@
+package com.example.todak_server.repository;
+
+import com.example.todak_server.entity.ChangeLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ChangeLogRepository extends JpaRepository<ChangeLog, Long> {
+
+    List<ChangeLog> findByMemberIdOrderByChangedAtDesc(Long memberId);
+}

--- a/todak-server/src/main/java/com/example/todak_server/repository/ChangeReadRepository.java
+++ b/todak-server/src/main/java/com/example/todak_server/repository/ChangeReadRepository.java
@@ -1,0 +1,13 @@
+package com.example.todak_server.repository;
+
+import com.example.todak_server.entity.ChangeRead;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ChangeReadRepository extends JpaRepository<ChangeRead, Long> {
+    
+    List<ChangeRead> findByMemberId(Long memberId);
+    List<ChangeRead> findByMemberIdAndIsReadFalse(Long memberId);
+    List<ChangeRead> findByIsReadFalseAndNotifiedFalse();
+}

--- a/todak-server/src/main/java/com/example/todak_server/service/ChangeService.java
+++ b/todak-server/src/main/java/com/example/todak_server/service/ChangeService.java
@@ -1,0 +1,127 @@
+package com.example.todak_server.service;
+
+import com.example.todak_server.entity.ChangeLog;
+import com.example.todak_server.entity.ChangeRead;
+import com.example.todak_server.repository.ChangeLogRepository;
+import com.example.todak_server.repository.ChangeReadRepository;
+import com.example.todak_server.dto.response.ChangeLogResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.time.LocalDateTime;
+import java.util.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ChangeService {
+
+    private final ChangeLogRepository changeLogRepo;
+    private final ChangeReadRepository changeReadRepo;
+
+    // 변경된 사항 감지 후 로그 저장
+    public void compareAndLog(Long memberId, String category,
+                              String field, String oldV, String newV) {
+
+        if (!Objects.equals(oldV, newV)) {
+
+            ChangeLog log = changeLogRepo.save(
+                    ChangeLog.builder()
+                            .memberId(memberId)
+                            .category(category)
+                            .fieldName(field)
+                            .oldValue(oldV)
+                            .newValue(newV)
+                            .changedAt(LocalDateTime.now())
+                            .build()
+            );
+
+            changeReadRepo.save(
+                    ChangeRead.builder()
+                            .memberId(memberId)
+                            .changeLogId(log.getId())
+                            .isRead(false)
+                            .notified(false)
+                            .createdAt(LocalDateTime.now())
+                            .build()
+            );
+        }
+    }
+
+    // 전체 변경사항 조회 (읽은 것 + 안 읽은 것)
+    public List<ChangeLogResponse> getChanges(Long memberId) {
+
+        // 직원의 읽기 상태 목록
+        List<ChangeRead> readList = changeReadRepo.findByMemberId(memberId);
+
+        List<Long> logIds = readList.stream()
+                .map(ChangeRead::getChangeLogId)
+                .toList();
+
+        // 실제 ChangeLog 조회
+        List<ChangeLog> logs = changeLogRepo.findAllById(logIds);
+
+        // 읽음 여부 Map으로 구성
+        Map<Long, Boolean> readStatusMap =
+                readList.stream()
+                        .collect(Collectors.toMap(
+                                ChangeRead::getChangeLogId,
+                                ChangeRead::isRead
+                        ));
+
+        return logs.stream()
+                .map(log -> new ChangeLogResponse(
+                        log.getId(),
+                        log.getCategory(),
+                        log.getFieldName(),
+                        log.getOldValue(),
+                        log.getNewValue(),
+                        log.getChangedAt(),
+                        readStatusMap.getOrDefault(log.getId(), false)   // 읽음 여부 포함
+                ))
+                .sorted(Comparator.comparing(ChangeLogResponse::changedAt).reversed())
+                .toList();
+    }
+
+    // 안 읽은 변경사항로그 조회
+    public List<ChangeLogResponse> getUnreadChanges(Long memberId) {
+
+        // 안 읽은 상태인 ChangeRead만 조회
+        List<ChangeRead> unreadList =
+                changeReadRepo.findByMemberIdAndIsReadFalse(memberId);
+
+        List<Long> ids = unreadList.stream()
+                .map(ChangeRead::getChangeLogId)
+                .toList();
+
+        List<ChangeLog> logs = changeLogRepo.findAllById(ids);
+
+        // 모두 isRead = false
+        return logs.stream()
+                .map(log -> new ChangeLogResponse(
+                        log.getId(),
+                        log.getCategory(),
+                        log.getFieldName(),
+                        log.getOldValue(),
+                        log.getNewValue(),
+                        log.getChangedAt(),
+                        false
+                ))
+                .sorted(Comparator.comparing(ChangeLogResponse::changedAt).reversed())
+                .toList();
+    }
+
+    // 읽음 처리
+    public void markAsRead(List<Long> changeLogIds, Long memberId) {
+
+        List<ChangeRead> list = changeReadRepo.findByMemberIdAndIsReadFalse(memberId);
+
+        for (ChangeRead cr : list) {
+            if (changeLogIds.contains(cr.getChangeLogId())) {
+                cr.setRead(true);
+                changeReadRepo.save(cr);
+            }
+        }
+    }
+}

--- a/todak-server/src/main/java/com/example/todak_server/service/FcmService.java
+++ b/todak-server/src/main/java/com/example/todak_server/service/FcmService.java
@@ -2,6 +2,7 @@ package com.example.todak_server.service;
 
 import com.example.todak_server.entity.Member;
 import com.example.todak_server.entity.MemberSetting;
+import com.example.todak_server.repository.MemberRepository;
 import com.example.todak_server.repository.MemberSettingRepository;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
@@ -25,6 +26,7 @@ public class FcmService {
 
     private final MemberSettingRepository memberSettingRepository;
     private ThreadPoolTaskScheduler scheduler;
+    private final MemberRepository memberRepository;
 
     @PostConstruct
     public void init() {
@@ -124,6 +126,35 @@ public class FcmService {
             System.out.println("FCM sent to " + member.getNickname() + ": " + response);
         } catch (Exception e) {
             System.err.println("Failed to send push to " + member.getNickname());
+            e.printStackTrace();
+        }
+    }
+
+    // MemberToken 설정
+    public String getMemberToken(Long memberId) {
+        return memberRepository.findById(memberId)
+                .map(Member::getFcmToken)
+                .orElse(null);
+    }
+
+    // 공지/리마인드 전송 로직
+    public void sendNotification(String token, String title, String body) {
+        if (token == null || token.isBlank()) return;
+
+        try {
+            Message message = Message.builder()
+                    .setToken(token)
+                    .setNotification(Notification.builder()
+                            .setTitle(title)
+                            .setBody(body)
+                            .build())
+                    .build();
+
+            String response = FirebaseMessaging.getInstance().send(message);
+            System.out.println("FCM sent: " + response);
+
+        } catch (Exception e) {
+            System.err.println("FCM send failed: " + e.getMessage());
             e.printStackTrace();
         }
     }


### PR DESCRIPTION
Resolved #38 


<br>

---


### 1. 특정 직원에게 해당하는 전체 변경사항 조회
```
GET /api/changes?memberId=3
```

- 특정 직원에게 공지되어야 할 전체 변경사항 조회
- 읽음 여부와 관계없이 전부 조회 
 


<details>
<summary>Postman 결과</summary>
<div markdown="1">


<img src="https://github.com/user-attachments/assets/948f23c7-2c43-4a4f-a37c-5cf86499a368" width="600"/>

</div>
</details>

<br>


### 2. 특정 직원이 읽지 않은 변경사항만 조회 

```
GET /api/changes/unread?memberId=3
```

- 특정 직원에게 공지된 변경사항들 중 읽지 않은 변경사항만 조회 


<details>
<summary>Postman 결과</summary>
<div markdown="1">



<img src="https://github.com/user-attachments/assets/cbc4e2ba-b994-4223-8d79-acda80b79638" width="600"/>

</div>
</details>

<br>


### 3. 변경사항 읽음 처리 

```
POST /api/changes/read 
```

- 변경사항을 읽고 체크박스에 체크하면, 해당 변경사항에 대해 읽음 처리 
- `changeLogIds`에 대해 읽음 처리 

<details>
<summary>Postman 결과</summary>
<div markdown="1">


<img src="https://github.com/user-attachments/assets/0d6c1fd0-a05d-4141-8a95-5c5f59dd2108" width="600"/>

</div>
</details>



<br>

- 참고로 관리자가 변경사항을 기록하는 기능은  API를 따로 호출하는 구조가 아님
- 서비스 내부에서 알아서 변경사항을 감지하고 ChangeLog/ChageRead에 자동으로 로그가 저장되는 구조임 
  -  ChangeService에서 전부 처리함 
  - 어떤 기능에서든 값이 바뀌는 지점이 생기면, Service 내부에서 `compareAndLog()`를 호출하도록 함 -> ChangeLog 생성 -> ChangeRead 자동 생성 
  - `isRead=false`인 항목을 빨간 글씨로 표시함 (아직 읽지 않은 변경사항이므로)

<br>

