### PR TITLE
Refactor: 특정 직원의 근무 스케줄 등록/수정/조회/삭제 기능으로 수정

### DIFF
--- a/todak-server/src/main/java/com/example/todak_server/controller/WorkScheduleController.java
+++ b/todak-server/src/main/java/com/example/todak_server/controller/WorkScheduleController.java
@@ -19,15 +19,18 @@ import java.util.List;
 @Tag(name = "근무 스케줄 API", description = "근무 스케줄 등록/수정/조회/삭제 기능 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/admin/schedules")
+@RequestMapping("/api/admin/members/{memberId}/schedules")
 public class WorkScheduleController {
 
     private final WorkScheduleService workScheduleService;
 
     // 스케줄 등록
-    @Operation(summary = "근무 스케줄 등록", description = "새로운 근무 스케줄을 등록함. 이미지 파일 업로드를 지원함.")
+    @Operation(summary = "근무 스케줄 등록", description = "관리자가 특정 직원에게 스케줄을 등록함. 이미지 파일 업로드를 지원함.")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<WorkScheduleDetailResponse> create(
+            @Parameter(description = "스케줄 등록할 직원 ID")
+            @PathVariable("memberId") Long memberId,
+
             @Parameter(description = "스케줄 정보(JSON)")
             @RequestPart("data") WorkScheduleCreateRequest request,
 
@@ -35,16 +38,19 @@ public class WorkScheduleController {
             @RequestPart(value = "imageFile", required = false) MultipartFile imageFile
     ) {
         return ResponseEntity.ok(
-                workScheduleService.create(request, imageFile)
+                workScheduleService.create(memberId, request, imageFile)
         );
     }
 
     // 스케줄 수정
-    @Operation(summary = "근무 스케줄 수정", description = "기존 근무 스케줄 정보를 수정함. 이미지도 교체 가능함.")
+    @Operation(summary = "근무 스케줄 수정", description = "직원의 기존 근무 스케줄 정보를 수정함. 이미지도 교체 가능함.")
     @PutMapping(value = "/{scheduleId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<WorkScheduleDetailResponse> update(
+            @Parameter(description = "스케줄 수정할 직원 ID")
+            @PathVariable("memberId") Long memberId,
+
             @Parameter(description = "스케줄 ID")
-            @PathVariable Long scheduleId,
+            @PathVariable("scheduleId") Long scheduleId,
 
             @Parameter(description = "수정할 스케줄 데이터(JSON)")
             @RequestPart("data") WorkScheduleUpdateRequest request,
@@ -53,17 +59,17 @@ public class WorkScheduleController {
             @RequestPart(value = "imageFile", required = false) MultipartFile imageFile
     ) {
         return ResponseEntity.ok(
-                workScheduleService.update(scheduleId, request, imageFile)
+                workScheduleService.update(memberId, scheduleId, request, imageFile)
         );
     }
 
     // 월별 스케줄 조회
-    @Operation(summary = "월별 스케줄 조회", description = "특정 구성원의 특정 연/월에 해당하는 근무 스케줄을 조회함.")
+    @Operation(summary = "월별 스케줄 조회", description = "직원의 특정 연/월에 해당하는 근무 스케줄을 조회함.")
     @GetMapping
     public ResponseEntity<List<WorkScheduleSimpleResponse>> getMonthly(
-            @Parameter(description = "멤버 ID") @RequestParam Long memberId,
-            @Parameter(description = "연도") @RequestParam int year,
-            @Parameter(description = "월") @RequestParam int month
+            @Parameter(description = "멤버 ID") @PathVariable("memberId") Long memberId,
+            @Parameter(description = "연도") @RequestParam("year") int year,
+            @Parameter(description = "월") @RequestParam("month") int month
     ) {
         return ResponseEntity.ok(
                 workScheduleService.getMonthly(memberId, year, month)
@@ -73,10 +79,11 @@ public class WorkScheduleController {
     // 스케줄 삭제
     @Operation(summary = "근무 스케줄 삭제", description = "스케줄 ID에 해당하는 근무 스케줄을 삭제함.")
     @DeleteMapping("/{scheduleId}")
-    public ResponseEntity<Void> delete(@PathVariable Long scheduleId) {
-
-        workScheduleService.delete(scheduleId);
-
+    public ResponseEntity<Void> delete(
+            @Parameter(description = "스케줄 수정할 직원 ID") @PathVariable("memberId") Long memberId,
+            @Parameter(description = "수정할 스케줄 ID") @PathVariable("scheduleId") Long scheduleId
+    ) {
+        workScheduleService.delete(memberId, scheduleId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/todak-server/src/main/java/com/example/todak_server/dto/request/WorkScheduleCreateRequest.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/request/WorkScheduleCreateRequest.java
@@ -7,9 +7,6 @@ import java.time.LocalTime;
 @Schema(description = "근무 스케줄 생성 요청 DTO")
 public record WorkScheduleCreateRequest(
 
-        @Schema(description = "근무 대상 직원 ID", example = "3")
-        Long memberId,
-
         @Schema(description = "근무 날짜", example = "2025-11-21")
         LocalDate date,
 

--- a/todak-server/src/main/java/com/example/todak_server/service/WorkScheduleService.java
+++ b/todak-server/src/main/java/com/example/todak_server/service/WorkScheduleService.java
@@ -26,10 +26,11 @@ public class WorkScheduleService {
 
     // 스케줄 등록
     public WorkScheduleDetailResponse create(
+            Long memberId,
             WorkScheduleCreateRequest req,
             MultipartFile imageFile
     ) {
-        Member member = memberRepository.findById(req.memberId())
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new RuntimeException("직원이 존재하지 않습니다."));
 
         String imgUrl = null;
@@ -52,6 +53,7 @@ public class WorkScheduleService {
 
     // 스케줄 수정
     public WorkScheduleDetailResponse update(
+            Long memberId,
             Long scheduleId,
             WorkScheduleUpdateRequest req,
             MultipartFile imageFile
@@ -113,7 +115,7 @@ public class WorkScheduleService {
     }
 
     // 스케줄 삭제
-    public void delete(Long scheduleId) {
+    public void delete(Long memberId, Long scheduleId) {
 
         WorkSchedule schedule = workScheduleRepository.findById(scheduleId)
                 .orElseThrow(() -> new RuntimeException("스케줄을 찾을 수 없습니다."));


### PR DESCRIPTION
Resolved #48 


<br>

---


### 1. 직원 스케줄 생성
```
POST /api/admin/members/{memberId}/schedules
```

- 관리자가 특정 직원에게 스케줄을 등록함
- 이미지 파일 업로드를 지원함 
 


<details>
<summary>Postman 결과</summary>
<div markdown="1">



<img src="https://github.com/user-attachments/assets/f8b78984-1481-4c12-893a-cac2916e97cd" width="600"/>

<img src="https://github.com/user-attachments/assets/030757bb-84a4-41f9-86e8-b17914b30bf3" width="600"/>



</div>
</details>

<br>


### 2. 직원 스케줄 수정 

```
PUT /api/admin/members/{memberId}/schedules/{scheduleId}
```

- 직원의 기존 근무 스케줄 정보를 수정함
- 이미지도 교체 가능함

<details>
<summary>Postman 결과</summary>
<div markdown="1">



<img src="https://github.com/user-attachments/assets/52e20921-df63-4b2e-ab29-24fb65ad82df" width="600"/>

</div>
</details>

<br>


### 3. 직원 월별 스케줄 조회

```
GET /api/admin/members/{memberId}/schedules?year=2025&month=11
```

- 직원의 특정 연/월에 해당하는 근무 스케줄을 조회함 




<details>
<summary>Postman 결과</summary>
<div markdown="1">


<img src="https://github.com/user-attachments/assets/6046975e-0b85-446d-9a2b-894bee60f562" width="600"/>

</div>
</details>




<br>


### 4. 직원 스케줄 삭제

```
DELETE /api/admin/members/{memberId}/schedules/{scheduleId}
```

- 스케줄 ID에 해당하는 근무 스케줄을 삭제함

<details>
<summary>Postman 결과</summary>
<div markdown="1">



<img src="https://github.com/user-attachments/assets/b19162db-8d06-4bad-87c7-c264624d8116" width="600"/>

</div>
</details>

<br>
