### PR TITLE
Feat: 소속 트리 구조에 부모노드인 기업 추가

### DIFF
--- a/todak-server/src/main/java/com/example/todak_server/controller/CompanyController.java
+++ b/todak-server/src/main/java/com/example/todak_server/controller/CompanyController.java
@@ -1,0 +1,54 @@
+package com.example.todak_server.controller;
+
+import com.example.todak_server.dto.request.CompanyCreateRequest;
+import com.example.todak_server.dto.request.CompanyUpdateRequest;
+import com.example.todak_server.dto.response.CompanyResponse;
+import com.example.todak_server.service.CompanyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "회사 관리 API", description = "회사 생성/수정/조회/삭제 등 회사 관련 관리자 기능 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/companies")
+public class CompanyController {
+
+    private final CompanyService companyService;
+
+    @Operation(summary = "회사 등록", description = "회사 이름, 대표자 정보 등 기본 정보를 입력하여 새로운 회사를 생성합니다.")
+    @PostMapping
+    public CompanyResponse create(@RequestBody CompanyCreateRequest req) {
+        return companyService.create(req);
+    }
+
+    @Operation(summary = "회사 수정", description = "회사 ID로 회사를 조회한 뒤, 회사명 또는 기본 정보를 수정합니다.")
+    @PutMapping("/{companyId}")
+    public CompanyResponse update(
+            @PathVariable("companyId") Long companyId,
+            @RequestBody CompanyUpdateRequest req
+    ) {
+        return companyService.update(companyId, req);
+    }
+
+    @Operation(summary = "회사 조회", description = "companyId를 기준으로 하나의 회사 정보를 조회합니다.")
+    @GetMapping("/{companyId}")
+    public CompanyResponse get(@PathVariable("companyId") Long companyId) {
+        return companyService.get(companyId);
+    }
+
+    @Operation(summary = "전체 회사 목록 조회", description = "등록된 모든 회사 목록을 조회합니다.")
+    @GetMapping
+    public List<CompanyResponse> getAll() {
+        return companyService.getAll();
+    }
+
+    @Operation(summary = "회사 삭제", description = "특정 회사 ID로 회사를 삭제합니다.")
+    @DeleteMapping("/{companyId}")
+    public void delete(@PathVariable("companyId") Long companyId) {
+        companyService.delete(companyId);
+    }
+}

--- a/todak-server/src/main/java/com/example/todak_server/controller/OrganizationUnitController.java
+++ b/todak-server/src/main/java/com/example/todak_server/controller/OrganizationUnitController.java
@@ -26,9 +26,11 @@ public class OrganizationUnitController {
 
     // 조직 조회
     @Operation(summary = "조직 트리 조회", description = "최상위 조직부터 전체 조직 구조(트리)를 조회함.")
-    @GetMapping("/tree")
-    public ResponseEntity<List<OrganizationUnitResponse>> getTree() {
-        return ResponseEntity.ok(organizationUnitService.getOrganizationTree());
+    @GetMapping("/companies/{companyId}/tree")
+    public ResponseEntity<List<OrganizationUnitResponse>> getTree(
+            @PathVariable("companyId") Long companyId
+    ) {
+        return ResponseEntity.ok(organizationUnitService.getOrganizationTree(companyId));
     }
 
     // 조직 등록

--- a/todak-server/src/main/java/com/example/todak_server/dto/request/CompanyCreateRequest.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/request/CompanyCreateRequest.java
@@ -1,0 +1,13 @@
+package com.example.todak_server.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "기업 단위 생성 요청 DTO")
+public record CompanyCreateRequest(
+
+        @Schema(description = "기업명", example = "기업 A")
+        String name,
+
+        @Schema(description = "기업에 대한 설명", example = "기업 A는 A입니다.")
+        String description
+) {}

--- a/todak-server/src/main/java/com/example/todak_server/dto/request/CompanyUpdateRequest.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/request/CompanyUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.example.todak_server.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "기업 단위 수정 요청 DTO")
+public record CompanyUpdateRequest(
+
+        @Schema(description = "기업명", example = "기업 A")
+        String name,
+
+        @Schema(description = "기업에 대한 설명", example = "기업 A는 A입니다.")
+        String description
+) {}

--- a/todak-server/src/main/java/com/example/todak_server/dto/request/OrganizationUnitCreateRequest.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/request/OrganizationUnitCreateRequest.java
@@ -5,6 +5,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "조직 단위(부서) 생성 요청 DTO")
 public record OrganizationUnitCreateRequest(
 
+        @Schema(description = "기업명", example = "기업 A")
+        Long companyId,
+
         @Schema(description = "조직명", example = "생산관리팀")
         String name,
 

--- a/todak-server/src/main/java/com/example/todak_server/dto/request/OrganizationUnitUpdateRequest.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/request/OrganizationUnitUpdateRequest.java
@@ -5,6 +5,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "조직 단위(부서) 수정 요청 DTO")
 public record OrganizationUnitUpdateRequest(
 
+        @Schema(description = "기업명", example = "기업 A")
+        Long companyId,
+
         @Schema(description = "조직명", example = "연구개발팀")
         String name,
 

--- a/todak-server/src/main/java/com/example/todak_server/dto/response/CompanyResponse.java
+++ b/todak-server/src/main/java/com/example/todak_server/dto/response/CompanyResponse.java
@@ -1,0 +1,14 @@
+package com.example.todak_server.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CompanyResponse(
+        @Schema(description = "기업 ID", example = "1")
+        Long id,
+
+        @Schema(description = "기업 이름", example = "기업 A")
+        String name,
+
+        @Schema(description = "기업 설명", example = "기업 A는 A입니다.")
+        String description
+) {}

--- a/todak-server/src/main/java/com/example/todak_server/entity/Company.java
+++ b/todak-server/src/main/java/com/example/todak_server/entity/Company.java
@@ -1,0 +1,24 @@
+package com.example.todak_server.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Company {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String description;
+
+    @OneToMany(mappedBy = "company", cascade = CascadeType.ALL)
+    private List<OrganizationUnit> organizationUnits = new ArrayList<>();
+}

--- a/todak-server/src/main/java/com/example/todak_server/entity/OrganizationUnit.java
+++ b/todak-server/src/main/java/com/example/todak_server/entity/OrganizationUnit.java
@@ -1,8 +1,7 @@
 package com.example.todak_server.entity;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -10,21 +9,32 @@ import java.util.List;
 @Entity
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class OrganizationUnit {
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id", nullable = false)
+    private Company company;
+
+    // 조직의 상위 조직
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private OrganizationUnit parent;
 
+    // 조직의 하위 조직들
     @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
     private List<OrganizationUnit> children = new ArrayList<>();
 
     public void addChild(OrganizationUnit child) {
         children.add(child);
-        child.parent = this;
+        child.setParent(this);
     }
 }
+

--- a/todak-server/src/main/java/com/example/todak_server/repository/CompanyRepository.java
+++ b/todak-server/src/main/java/com/example/todak_server/repository/CompanyRepository.java
@@ -1,0 +1,7 @@
+package com.example.todak_server.repository;
+
+import com.example.todak_server.entity.Company;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CompanyRepository extends JpaRepository<Company, Long> {
+}

--- a/todak-server/src/main/java/com/example/todak_server/repository/OrganizationUnitRepository.java
+++ b/todak-server/src/main/java/com/example/todak_server/repository/OrganizationUnitRepository.java
@@ -11,4 +11,6 @@ public interface OrganizationUnitRepository extends JpaRepository<OrganizationUn
     // 부모가 없는 최상위 조직만 조회
     List<OrganizationUnit> findByParentIsNull();
     Optional<OrganizationUnit> findByName(String name);
+    List<OrganizationUnit> findByCompanyIdAndParentIsNull(Long companyId);
+
 }

--- a/todak-server/src/main/java/com/example/todak_server/service/CompanyService.java
+++ b/todak-server/src/main/java/com/example/todak_server/service/CompanyService.java
@@ -1,0 +1,67 @@
+package com.example.todak_server.service;
+
+import com.example.todak_server.dto.request.CompanyCreateRequest;
+import com.example.todak_server.dto.request.CompanyUpdateRequest;
+import com.example.todak_server.dto.response.CompanyResponse;
+import com.example.todak_server.entity.Company;
+import com.example.todak_server.repository.CompanyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CompanyService {
+
+    private final CompanyRepository companyRepository;
+
+    public CompanyResponse create(CompanyCreateRequest req) {
+        Company c = Company.builder()
+                .name(req.name())
+                .description(req.description())
+                .build();
+
+        companyRepository.save(c);
+
+        return toResponse(c);
+    }
+
+    public CompanyResponse update(Long companyId, CompanyUpdateRequest req) {
+        Company c = companyRepository.findById(companyId)
+                .orElseThrow(() -> new RuntimeException("기업을 찾을 수 없습니다."));
+
+        c.setName(req.name());
+        c.setDescription(req.description());
+
+        companyRepository.save(c);
+
+        return toResponse(c);
+    }
+
+    public void delete(Long companyId) {
+        companyRepository.deleteById(companyId);
+    }
+
+    public CompanyResponse get(Long companyId) {
+        Company c = companyRepository.findById(companyId)
+                .orElseThrow(() -> new RuntimeException("기업을 찾을 수 없습니다."));
+
+        return toResponse(c);
+    }
+
+    public List<CompanyResponse> getAll() {
+        return companyRepository.findAll()
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private CompanyResponse toResponse(Company c) {
+        return new CompanyResponse(
+                c.getId(),
+                c.getName(),
+                c.getDescription()
+        );
+    }
+}

--- a/todak-server/src/main/java/com/example/todak_server/service/OrganizationUnitService.java
+++ b/todak-server/src/main/java/com/example/todak_server/service/OrganizationUnitService.java
@@ -7,11 +7,9 @@ import com.example.todak_server.dto.request.OrganizationUnitUpdateRequest;
 import com.example.todak_server.dto.response.EmployeeDetailResponse;
 import com.example.todak_server.dto.response.EmployeeResponse;
 import com.example.todak_server.dto.response.OrganizationUnitResponse;
-import com.example.todak_server.entity.AccessPermission;
-import com.example.todak_server.entity.Member;
-import com.example.todak_server.entity.OrganizationUnit;
-import com.example.todak_server.entity.Role;
+import com.example.todak_server.entity.*;
 import com.example.todak_server.repository.AccessPermissionRepository;
+import com.example.todak_server.repository.CompanyRepository;
 import com.example.todak_server.repository.MemberRepository;
 import com.example.todak_server.repository.OrganizationUnitRepository;
 import lombok.RequiredArgsConstructor;
@@ -27,11 +25,13 @@ public class OrganizationUnitService {
     private final OrganizationUnitRepository organizationUnitRepository;
     private final MemberRepository memberRepository;
     private final AccessPermissionRepository accessPermissionRepository;
+    private final CompanyRepository companyRepository;
 
+    // 기업별 트리 전체 조회
+    public List<OrganizationUnitResponse> getOrganizationTree(Long companyId) {
 
-    // 조직 트리 전체 조회
-    public List<OrganizationUnitResponse> getOrganizationTree() {
-        List<OrganizationUnit> roots = organizationUnitRepository.findByParentIsNull();
+        List<OrganizationUnit> roots = organizationUnitRepository
+                .findByCompanyIdAndParentIsNull(companyId);
 
         return roots.stream()
                 .map(this::convertToResponse)
@@ -55,6 +55,9 @@ public class OrganizationUnitService {
     @Transactional
     public Long createOrganizationUnit(OrganizationUnitCreateRequest request) {
 
+        Company company = companyRepository.findById(request.companyId())
+                .orElseThrow(() -> new IllegalArgumentException("Company not found"));
+
         OrganizationUnit parent = null;
 
         if (request.parentId() != null) {
@@ -65,6 +68,7 @@ public class OrganizationUnitService {
         OrganizationUnit unit = new OrganizationUnit();
         unit.setName(request.name());
         unit.setParent(parent);
+        unit.setCompany(company);
 
         OrganizationUnit saved = organizationUnitRepository.save(unit);
         return saved.getId();
@@ -77,14 +81,22 @@ public class OrganizationUnitService {
         OrganizationUnit unit = organizationUnitRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Organization not found"));
 
+        // 이름 변경
         if (request.name() != null) {
             unit.setName(request.name());
         }
 
+        // 소속 회사 변경
+        if (request.companyId() != null) {
+            Company company = companyRepository.findById(request.companyId())
+                    .orElseThrow(() -> new IllegalArgumentException("Company not found"));
+            unit.setCompany(company);
+        }
+
+        // 상위 조직 변경
         if (request.parentId() != null) {
             OrganizationUnit parent = organizationUnitRepository.findById(request.parentId())
                     .orElseThrow(() -> new IllegalArgumentException("Parent not found"));
-
             unit.setParent(parent);
         }
     }
@@ -107,12 +119,9 @@ public class OrganizationUnitService {
         // 2) 조직 이름으로 조직 찾기
         OrganizationUnit org = organizationUnitRepository
                 .findById(request.organizationUnitId())
-                .orElseThrow(() -> new IllegalArgumentException("Organization not found: " + request.organizationUnitId()));
+                .orElseThrow(() -> new IllegalArgumentException("조직을 찾을 수 없습니다."));
 
-        // 3) 멤버의 조직 업데이트
         employee.setOrganizationUnit(org);
-
-        // 저장 후 멤버 id 반환
         memberRepository.save(employee);
 
         return employee.getId();
@@ -144,7 +153,7 @@ public class OrganizationUnitService {
     // 직원 상세 조회
     public EmployeeDetailResponse getEmployeeDetail(Long memberId) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("Employee not found"));
+                .orElseThrow(() -> new IllegalArgumentException("직원을 찾을 수 없습니다."));
 
         return new EmployeeDetailResponse(
                 member.getId(),
@@ -163,7 +172,7 @@ public class OrganizationUnitService {
     public void updateEmployeePermission(Long memberId, AccessPermissionUpdateRequest request) {
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("Employee not found"));
+                .orElseThrow(() -> new IllegalArgumentException("직원을 찾을 수 없습니다."));
 
         AccessPermission permission = member.getAccessPermission();
 
@@ -185,15 +194,15 @@ public class OrganizationUnitService {
     @Transactional
     public void deleteOrganization(Long id) {
         OrganizationUnit unit = organizationUnitRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("Organization not found"));
+                .orElseThrow(() -> new IllegalArgumentException("조직을 찾을 수 없습니다."));
 
         if (!unit.getChildren().isEmpty()) {
-            throw new IllegalStateException("Cannot delete organization that has sub-organizations");
+            throw new IllegalStateException("하위 조직을 가진 조직을 삭제할 수 없습니다.");
         }
 
         // 직원도 남아있으면 삭제 불가
         if (memberRepository.existsByOrganizationUnit(unit)) {
-            throw new IllegalStateException("Cannot delete organization that has employees");
+            throw new IllegalStateException("직원들이 저장된 조직을 삭제할 수 없습니다.");
         }
 
         organizationUnitRepository.delete(unit);
@@ -203,7 +212,7 @@ public class OrganizationUnitService {
     @Transactional
     public void deleteEmployee(Long memberId) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("Employee not found"));
+                .orElseThrow(() -> new IllegalArgumentException("직원을 찾을 수 없습니다."));
 
         member.setOrganizationUnit(null); // 소속만 제거
         memberRepository.delete(member);

--- a/todak-server/src/main/resources/application-dev.yml
+++ b/todak-server/src/main/resources/application-dev.yml
@@ -17,4 +17,4 @@ gcp:
     project-id: todak-for-daily
     bucket: todak-images
 server:
-  port: 8080
+  port: 8081


### PR DESCRIPTION
Resolved #51 

- 직원들의 소속을 트리 구조로 나타냄
  - 기업 > 조직 > 직원
- 현재 구현된 트리구조에는 `조직 > 직원`만 있기 때문에 조직의 상위 부모노드에 `기업` 추가 

<br>

---


### 1. 기업 생성
```
POST /api/companies
```

- 회사 이름, 회사에 대한 설명을 기입하여 등록함 
 

<details>
<summary>Postman 결과</summary>
<div markdown="1">




<img src="https://github.com/user-attachments/assets/8fca3ad8-6825-4311-8508-378ba7135232" width="600"/>





</div>
</details>


<br>


### 2. 기업 수정 

```
PUT /api/companies/{companyId} 
```

- 회사 ID로 회사를 조회한 뒤, 회사명 또는 설명을 수정함 
 
 
<details>
<summary>Postman 결과</summary>
<div markdown="1">



<img src="https://github.com/user-attachments/assets/48c98b88-7f34-4d64-ac40-79ba854e6cfc" width="600"/>



<img src="https://github.com/user-attachments/assets/b3bd7a33-0bbc-433e-a726-8b07a7a71188" width="600"/>


</div>
</details>


<br>

### 3. 단일 기업 조회 
```
GET /api/companies/{companyId}
```

- 회사 ID로 하나의 회사 정보를 조회함 
 

<details>
<summary>Postman 결과</summary>
<div markdown="1">



<img src="https://github.com/user-attachments/assets/aeb34f1b-c771-4127-b085-a452650ec573" width="600"/>



</div>
</details>

<br>

### 4. 전체 회사 목록 조회 
```
GET /api/companies
```

- 등록된 전체 기업 목록 조회 
 


<details>
<summary>Postman 결과</summary>
<div markdown="1">


<img src="https://github.com/user-attachments/assets/948c2d4c-eb1f-4490-bf1d-13da7c8d1013" width="600"/>




</div>
</details>


<br>

### 5. 기업 삭제 
```
POST /api/companies
```

- 회사 ID로 회사 삭제  
 


<details>
<summary>Postman 결과</summary>
<div markdown="1">



<img src="https://github.com/user-attachments/assets/9e255f42-6578-4f04-a724-d26a66feae1c" width="600"/>


</div>
</details>


<br>

